### PR TITLE
Added Content-type header for 503 response

### DIFF
--- a/lib/rack/alpaca.rb
+++ b/lib/rack/alpaca.rb
@@ -22,7 +22,7 @@ module Rack
         if whitelisted?('whitelist', req)
           @app.call(env)
         elsif blacklisted?('blacklist', req)
-          [503, {}, ["Request blocked\n"]]
+          [503, { "Content-Type"=>"text/plain" }, ["Request blocked\n"]]
         else
           default_strategy(env)
         end
@@ -34,7 +34,7 @@ module Rack
         if @default == 'allow'
           @app.call(env)
         elsif @default == 'deny'
-          [503, {}, ["Request blocked\n"]]
+          [503, { "Content-Type"=>"text/plain" }, ["Request blocked\n"]]
         else
           raise 'Unknown default strategy'
         end


### PR DESCRIPTION
Instead of having a "503 Service unavailable" response when it is blacklist, it's being raised a "500 Internal Server Error" with "Rack::Lint::LintError: No Content-Type header found" exception.

I had this problem using Sinatra in development environment and running a Rack server (rackup). It happens because rackup servers automatically add Rack::Lint in development mode.

To ensure Rack protocol is being followed, there must be a Content-type header in all responses, except when the status is 1xx, 204 or 304.
